### PR TITLE
add multi processes producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 dependency-reduced-pom.xml
 logmatters.iml
+nohup.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target/
 /log/
+.idea/
+dependency-reduced-pom.xml
+logmatters.iml

--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ Edit the configuration file [here](https://github.com/dashbase/logmatters/blob/m
 ```./bin/testlog.sh```
 
 Logs are generated under `logs` directory
+
+### Run multi processed
+#### Run 3 producer
+```./bin/runner.sh 3```
+process-1 write logs to `logs/dashbase-1.log`
+...
+process-3 write logs to `logs/dashbase-3.log`
+
+#### Run 3 producer each with rotate second 30s
+```./bin/runner.sh 3 30```
+
+#### Kill all producer
+```./bin/kill.sh```

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Logs are generated under `logs` directory
 
 ### Run multi processed
 #### Run 3 producer
-```./bin/runner.sh 3```
+```./bin/run.sh 3```
 process-1 write logs to `logs/dashbase-1.log`
 ...
 process-3 write logs to `logs/dashbase-3.log`
 
-#### Run 3 producer each with rotate second 30s
-```./bin/runner.sh 3 30```
+#### Run 3 producer each with throttle limit 30
+```./bin/run.sh 3 30```
 
 #### Kill all producer
 ```./bin/kill.sh```

--- a/README.md
+++ b/README.md
@@ -28,13 +28,37 @@ Logs are generated under `logs` directory
 
 ### Run multi processed
 #### Run 3 producer
-```./bin/run.sh 3```
-process-1 write logs to `/logs/dashbase-1-xxx.log`
-...
-process-3 write logs to `/logs/dashbase-3-xxx.log`
+```
+$ ./bin/run.sh 3
+Started the process 1 with Log name: /logs/dashbase-1544179256-1.log...
+Started the process 2 with Log name: /logs/dashbase-1544179256-2.log...
+Started the process 3 with Log name: /logs/dashbase-1544179256-3.log...
+Got Identifier(group name) of these process: 1544179256
+You can kill them by `./bin/kill.sh 1544179256`
+appending output to nohup.out                                                                                                                                             
+appending output to nohup.out
+appending output to nohup.out
+
+```
+#### Kill these producers
+```
+$ ./bin/kill.sh 1544179256`
+```
 
 #### Run 3 producer each with throttle limit 30
 ```./bin/run.sh 3 30```
+
+#### Show producer info(use regular expressions to match, maybe too slow)
+```
+$ python ./bin/show.py
+Producer group 1544184708 have 3 producers with throttle 30.
+Producer group 1544185211 have 2 producers with throttle 20.
+Producer group 1544185223 have 3 producers with throttle -1.
+Producer group 1544185281 have 4 producers with throttle -1.
+Producer group 1544185307 have 50 producers with throttle 1.
+You can kill group by `./bin/kill.sh <group-name>`, or use `./bin/kill.sh` to kill them all.
+Use `ps -ef | grep java` to get all running processed.
+```
 
 #### Kill all producer
 ```./bin/kill.sh```

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Logs are generated under `logs` directory
 ### Run multi processed
 #### Run 3 producer
 ```./bin/run.sh 3```
-process-1 write logs to `logs/dashbase-1.log`
+process-1 write logs to `/logs/dashbase-1.log`
 ...
-process-3 write logs to `logs/dashbase-3.log`
+process-3 write logs to `/logs/dashbase-3.log`
 
 #### Run 3 producer each with throttle limit 30
 ```./bin/run.sh 3 30```

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Logs are generated under `logs` directory
 ### Run multi processed
 #### Run 3 producer
 ```./bin/run.sh 3```
-process-1 write logs to `/logs/dashbase-1.log`
+process-1 write logs to `/logs/dashbase-1-xxx.log`
 ...
-process-3 write logs to `/logs/dashbase-3.log`
+process-3 write logs to `/logs/dashbase-3-xxx.log`
 
 #### Run 3 producer each with throttle limit 30
 ```./bin/run.sh 3 30```

--- a/bin/kill.sh
+++ b/bin/kill.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
-pkill -f "java -Dprocessname=dashbase-log"
+if [ x"$1" = x ]; then
+    pkill -f "java -Dprocessname=dashbase-log"
+else
+    pkill -f "java -Dprocessname=dashbase-log -Didentifier=$1"
+fi

--- a/bin/kill.sh
+++ b/bin/kill.sh
@@ -4,3 +4,4 @@ if [ x"$1" = x ]; then
 else
     pkill -f "java -Dprocessname=dashbase-log -Didentifier=$1"
 fi
+exit 0

--- a/bin/kill.sh
+++ b/bin/kill.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+pkill -f "java -Dprocessname=dashbase-log"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -16,9 +16,9 @@ epoch=`date +%s`
 for i in `seq 1 $1`
 do
     if [ x"$2" = x ]; then
-        nohup java  -Dprocessname=dashbase-log -Didentifier=$epoch -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java  -Dprocessname=dashbase-log -Didentifier=$epoch -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml > /tmp/logmatters.log &
     else
-        nohup java -Dprocessname=dashbase-log -Didentifier=$epoch -Ddw.throttleNPerSec=$2 -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java -Dprocessname=dashbase-log -Didentifier=$epoch -Ddw.throttleNPerSec=$2 -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml > /tmp/logmatters.log &
     fi
     echo "Started the process $i with Log name: /logs/dashbase-$epoch-$i.log..."
 done

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,12 +11,12 @@ lib=${dist}/lib
 logs=/logs
 cd ${basedir}
 
-for((i = 1; i <= $1; i++))
+for i in `seq 1 $1`
 do
     if [ x"$2" = x ]; then
         nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     else
         nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     fi
-    echo "Started the process $i with Log name: dashbase-$i.log..."
+    echo "Started the process $i with Log name: /logs/dashbase-$i.log..."
 done

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#java -jar target/logmatters-0.0.1-SNAPSHOT.jar server conf/config.yml
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+basedir=${bin}/..
+conf=${basedir}/conf
+dist=${basedir}/target
+lib=${dist}/lib
+logs=${basedir}/logs
+cd ${basedir}
+
+for((i = 1; i <= $1; i++))
+do
+    if [ x"$2" = x ]; then
+        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d-%i.log -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+    else
+        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d-%i.log -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+    fi
+    echo "Started the process $i with Log name: dashbase-$i.log..."
+done

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -8,15 +8,19 @@ basedir=${bin}/..
 conf=${basedir}/conf
 dist=${basedir}/target
 lib=${dist}/lib
-logs=/logs
+logs=${LOG_PATH:-log}
 cd ${basedir}
+
+epoch=`date +%s`
 
 for i in `seq 1 $1`
 do
     if [ x"$2" = x ]; then
-        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i-`date +%s`.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-`date +%s`.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java  -Dprocessname=dashbase-log -Didentifier=$epoch -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     else
-        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i-`date +%s`.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-`date +%s`.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java -Dprocessname=dashbase-log -Didentifier=$epoch -Ddw.throttleNPerSec=$2 -Dtotal=$1 ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$epoch-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$epoch-$i.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     fi
-    echo "Started the process $i with Log name: /logs/dashbase-$i-xxx.log..."
+    echo "Started the process $i with Log name: /logs/dashbase-$epoch-$i.log..."
 done
+echo "Got Identifier of these process: $epoch"
+echo "You can kill them by \`./bin/kill.sh $epoch\`"

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -14,9 +14,9 @@ cd ${basedir}
 for i in `seq 1 $1`
 do
     if [ x"$2" = x ]; then
-        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i-`date +%s`.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-`date +%s`.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     else
-        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i-`date +%s`.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-`date +%s`.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     fi
-    echo "Started the process $i with Log name: /logs/dashbase-$i.log..."
+    echo "Started the process $i with Log name: /logs/dashbase-$i-xxx.log..."
 done

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -8,15 +8,15 @@ basedir=${bin}/..
 conf=${basedir}/conf
 dist=${basedir}/target
 lib=${dist}/lib
-logs=${basedir}/logs
+logs=/logs
 cd ${basedir}
 
 for((i = 1; i <= $1; i++))
 do
     if [ x"$2" = x ]; then
-        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d-%i.log -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java  -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     else
-        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d-%i.log -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
+        nohup java -Dprocessname=dashbase-log ${JAVA_OPTS} ${HEAP_OPTS} ${GC_OPTS} ${JMX_OPTS} ${JAVA_DEBUG} -Ddw.throttleNPerSec=$2 -Ddw.logging.appenders[0].currentLogFilename=${logs}/dashbase-$i.log -Ddw.logging.appenders[0].archivedLogFilenamePattern=${logs}/dashbase-$i-%d.log.%i -jar ${dist}/logmatters-0.0.1-SNAPSHOT.jar server ${conf}/config.yml &
     fi
     echo "Started the process $i with Log name: dashbase-$i.log..."
 done

--- a/bin/show.py
+++ b/bin/show.py
@@ -1,0 +1,32 @@
+import re
+import subprocess
+
+p = subprocess.Popen('ps -ef | grep java', shell=True, stdout=subprocess.PIPE)
+out, err = p.communicate()
+re_identifier = re.compile(r'.*identifier=(\d+).*')
+re_total = re.compile(r'.*total=(\d+).*')
+re_throttlenpersec = re.compile(r'.*throttleNPerSec=(\d+).*')
+outs = out.decode('utf-8').split('\n')
+
+# identifier list
+identifiers = {}
+
+if __name__ == '__main__':
+    for line in outs:
+        r = re_identifier.match(line)
+        if r:  # matched
+            identifier = r.group(1)
+            if identifier not in identifiers:
+                total = re_total.match(line).group(1)
+                throttle = re_throttlenpersec.match(line)
+                if throttle:
+                    identifiers[r.group(1)] = {"throttle": throttle.group(1), "total": total}
+                else:
+                    identifiers[r.group(1)] = {"throttle": -1, "total": total}
+
+    for identifier in identifiers:
+        print(
+            "Producer group {} have {} producers with throttle {}.".format(identifier, identifiers[identifier]['total'],
+                                                                           identifiers[identifier]['throttle']))
+    print("You can kill group by `./bin/kill.sh <group-number>`, or use `./bin/kill.sh` to kill them all.")
+    print("Use `ps -ef | grep java` to get all running processed.")

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -6,10 +6,10 @@ logging:
       - type: file
         currentLogFilename: logs/logmatters.log
         archive: true
-        archivedLogFilenamePattern: logs/logmatters-%d-%i.log
+        archivedLogFilenamePattern: logs/logmatters-%d.log.%i
         archivedFileCount: 7
         timeZone: UTC
-        maxFileSize: 100MB
+        maxFileSize: 10MB
         logFormat: "%-5p [%d{ISO8601}] %c: %replace(%msg){'[\r\n]+','\\\\n'} %replace(%ex){'[\r\n]+', '\\\\n'}%nopex%n"
       #- type: console
        # logFormat: "%-5p [%d{ISO8601}] %c: %replace(%msg){'[\r\n]+','\\\\n'} %replace(%ex){'[\r\n]+', '\\\\n'}%nopex%n"


### PR DESCRIPTION
### Run multi processes
#### Run 3 producer
```
$ ./bin/run.sh 3
Started the process 1 with Log name: /logs/dashbase-1544179256-1.log...
Started the process 2 with Log name: /logs/dashbase-1544179256-2.log...
Started the process 3 with Log name: /logs/dashbase-1544179256-3.log...
Got Identifier(group name) of these process: 1544179256
You can kill them by `./bin/kill.sh 1544179256`
appending output to nohup.out                                                                                                                                             
appending output to nohup.out
appending output to nohup.out

```
#### Kill these producers
```
$ ./bin/kill.sh 1544179256`
```

#### Run 3 producer each with throttle limit 30
```./bin/run.sh 3 30```

#### Show producer info(use regular expressions to match, maybe too slow)
```
$ python ./bin/show.py
Producer group 1544184708 have 3 producers with throttle 30.
Producer group 1544185211 have 2 producers with throttle 20.
Producer group 1544185223 have 3 producers with throttle -1.
Producer group 1544185281 have 4 producers with throttle -1.
Producer group 1544185307 have 50 producers with throttle 1.
You can kill group by `./bin/kill.sh <group-name>`, or use `./bin/kill.sh` to kill them all.
Use `ps -ef | grep java` to get all running processed.
```

#### Kill all producer
```./bin/kill.sh```